### PR TITLE
fix: use contain instead of fill for CardImage

### DIFF
--- a/src/components/Card/Card.styled.ts
+++ b/src/components/Card/Card.styled.ts
@@ -55,7 +55,7 @@ export const RightSection = styled('div')(props => {
 export const CardImage = styled('img')({
   width: '100%',
   height: '100%',
-  objectFit: 'fill',
+  objectFit: 'contain',
   objectPosition: 'center'
 })
 


### PR DESCRIPTION
## Before this change:

![image](https://github.com/user-attachments/assets/3f9ae8b7-d08e-4bb0-8f64-ed85a91407b4)

## After this change:

![image](https://github.com/user-attachments/assets/242097fa-f932-4c63-bc80-ae5800ac0c25)

