### PR TITLE
fix: Parsing position and fetch events by world name

### DIFF
--- a/src/components/Pages/PlacesPage/PlacesPage.tsx
+++ b/src/components/Pages/PlacesPage/PlacesPage.tsx
@@ -1,19 +1,17 @@
-import { memo, useEffect, useMemo, useState, type FC } from 'react'
-import { useSearchParams, useNavigate } from 'react-router-dom'
+import { memo, useEffect, useState, type FC } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQueryParams } from '../../../hooks/useQueryParams'
 import { fromPlace, type CardData } from '../../../utils/cardDataTransformers'
 import { Creator, PeerApi } from '../../../utils/peerApi'
 import { fetchPlaces } from '../../../utils/placesApi'
 import { MainPageContainer } from '../../MainPageContainer/MainPage.styled'
 import { ResponsiveCard } from '../../ResponsiveCard'
 
-const DEFAULT_POSITION = '0,0'
-const DEFAULT_REALM = 'main'
-
 const peerApi = new PeerApi()
 
 export const PlacesPage: FC = memo(() => {
-  const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+  const { position, realm } = useQueryParams()
   const [places, setPlaces] = useState<CardData[]>([])
   const [creator, setCreator] = useState<Creator>({
     user_name: '',
@@ -22,20 +20,11 @@ export const PlacesPage: FC = memo(() => {
   })
   const [isLoading, setIsLoading] = useState(true)
 
-  const position = searchParams.get('position') ?? DEFAULT_POSITION
-  const realm = searchParams.get('realm') ?? DEFAULT_REALM
-
-  // Convert position string to coordinates array
-  const coordinates: [number, number] = useMemo(() => {
-    const [x, y] = position.split(',').map(Number)
-    return [x || 0, y || 0]
-  }, [position])
-
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true)
       try {
-        const response = await fetchPlaces({ position: coordinates, realm })
+        const response = await fetchPlaces({ position: position.coordinates, realm })
         if (response.ok && response.data.length > 0) {
           // Transform places data using the fromPlace utility
           const transformedPlaces = response.data.map(fromPlace)
@@ -59,7 +48,7 @@ export const PlacesPage: FC = memo(() => {
     }
 
     fetchData()
-  }, [coordinates, navigate])
+  }, [position.coordinates, realm, navigate])
 
   return (
     <MainPageContainer>

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+export const DEFAULT_POSITION = '0,0'
+export const DEFAULT_REALM = 'main'
+
+export interface ParsedPosition {
+  original: string
+  coordinates: [number, number]
+}
+
+export interface QueryParams {
+  position: ParsedPosition
+  realm: string
+  id?: string | null
+}
+
+/**
+ * Parses a position string into coordinates
+ * @param position Position string in format "x,y" or "x.y"
+ * @returns Parsed coordinates with original string
+ */
+const parsePosition = (position: string): ParsedPosition => {
+  const original = position
+  // Replace dots with commas for consistency
+  const normalizedPosition = position.replace('.', ',')
+  // Split and convert to numbers, defaulting to 0 if invalid
+  const [x, y] = normalizedPosition.split(',').map(coord => {
+    const num = Number(coord)
+    return isNaN(num) ? 0 : num
+  })
+
+  return {
+    original,
+    coordinates: [x, y]
+  }
+}
+
+/**
+ * Custom hook to handle common query parameters
+ * @returns Processed query parameters
+ */
+export const useQueryParams = (): QueryParams => {
+  const [searchParams] = useSearchParams()
+
+  return useMemo(() => {
+    const position = searchParams.get('position') ?? DEFAULT_POSITION
+    const realm = searchParams.get('realm') ?? DEFAULT_REALM
+    const id = searchParams.get('id')
+
+    return {
+      position: parsePosition(position),
+      realm,
+      id
+    }
+  }, [searchParams])
+}

--- a/src/utils/eventApi.ts
+++ b/src/utils/eventApi.ts
@@ -27,13 +27,26 @@ export class EventsApi {
 
   /**
    * Fetches events from the Decentraland Events API
-   * @param position Optional position coordinates to filter events [x, y]
+   * @param options Optional parameters to filter events
    * @param fetchFn Optional fetch function (defaults to global fetch)
    * @returns Promise with events data
    */
-  async fetchEvents(position?: [number, number], fetchFn: FetchFunction = fetch): Promise<EventsApiResponse> {
+  async fetchEvents(options?: { position?: [number, number]; realm?: string }, fetchFn: FetchFunction = fetch): Promise<EventsApiResponse> {
     try {
-      const url = position ? `${this.baseUrl}/events?position=${position[0]},${position[1]}` : `${this.baseUrl}/events`
+      let url = `${this.baseUrl}/events`
+      const params = new URLSearchParams()
+
+      if (options?.position) {
+        params.set('position', `${options.position[0]},${options.position[1]}`)
+      }
+
+      if (options?.realm) {
+        params.set('world_names[]', options.realm)
+      }
+
+      if (params.toString()) {
+        url += `?${params.toString()}`
+      }
 
       const response = await fetchFn(url)
 
@@ -47,6 +60,26 @@ export class EventsApi {
       console.error('Error fetching events:', error)
       throw error
     }
+  }
+
+  /**
+   * Fetches events by position (backward compatibility)
+   * @param position Optional position coordinates to filter events [x, y]
+   * @param fetchFn Optional fetch function (defaults to global fetch)
+   * @returns Promise with events data
+   */
+  async fetchEventsByPosition(position?: [number, number], fetchFn: FetchFunction = fetch): Promise<EventsApiResponse> {
+    return this.fetchEvents({ position }, fetchFn)
+  }
+
+  /**
+   * Fetches events by realm
+   * @param realm The realm name to filter events
+   * @param fetchFn Optional fetch function (defaults to global fetch)
+   * @returns Promise with events data
+   */
+  async fetchEventsByRealm(realm: string, fetchFn: FetchFunction = fetch): Promise<EventsApiResponse> {
+    return this.fetchEvents({ realm }, fetchFn)
   }
 
   /**


### PR DESCRIPTION
This PR fixes the parsing position to accept coordinates in the formats `X,Y` and `X.Y`.

Also, it added support for events using the realm name.